### PR TITLE
prevent self-hosted merges from breaking runs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
     - name: Run the installer
       run: |
         cd self-hosted
-        ./install.sh --no-report-self-hosted-issues
+        ./install.sh --no-report-self-hosted-issues --skip-commit-check
       shell: bash
     - name: Run tests
       shell: bash


### PR DESCRIPTION
if a change to self-hosted is made between the checkout and `./install.sh` call then this crashes with:

```
Checking for latest commit ... 
  Seems like you are not using the latest commit from the self-hosted repository. Please pull the latest changes and try again, or suppress this check with --skip-commit-check.
```