### PR TITLE
Return code typo fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
         set +e
         cd self-hosted
         ./test.sh
-        test_returns=$?
+        test_return=$?
         set -e
         if [[ $test_return -ne 0 ]]; then
           echo "Test failed.";


### PR DESCRIPTION
self hosted e2e test action not failing properly because of this typo