### PR TITLE
feat: Make docker pull optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,10 @@ inputs:
   project_name:
     required: true
     description: "e.g. snuba, sentry, relay, self-hosted"
+  pull_docker_image:
+    required: false
+    default: true
+    description: "Control whether the docker container should be pulled or not."
   image_url:
     required: true
     description: "The URL to the built relay, snuba, sentry image to test against."
@@ -31,7 +35,7 @@ runs:
       shell: bash
       run: curl -sL https://sentry.io/get-cli/ | sh
     - name: Pull the test image
-      if: ${{ inputs.project_name != 'self-hosted' }}
+      if: ${{ inputs.project_name != 'self-hosted' and inputs.pull_docker_image == true }}
       id: image_pull
       env:
         IMAGE_URL: ${{ inputs.image_url }}


### PR DESCRIPTION
I was trying to get the relay CI working for external pull requests which run into issues with uploading images to ghcr.

It's possible to use docker save and load to share a built image with workflows but to use that loaded image with this test, it shouldn't wait for docker pull.