### PR TITLE
feat: Do not pull image if we have it locally

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,7 @@ runs:
         echo "We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out."
         echo "Polling for $IMAGE_URL"
         until docker pull "$IMAGE_URL" 2>/dev/null; do
+           echo "Sleeping 10s before polling for $IMAGE_URL"
            sleep 10
         done
     - name: Configure to use the test image

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         IMAGE_URL: ${{ inputs.image_url }}
       shell: bash
       run: |
-        docker image inspect "$IMAGE_URL"
+        docker image inspect "$IMAGE_URL" &> /dev/null
         if [ $? -eq 0 ]
         then
           echo "Docker image already found."

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,13 @@ runs:
         IMAGE_URL: ${{ inputs.image_url }}
       shell: bash
       run: |
+        docker image inspect "$IMAGE_URL"
+        if [ $? -eq 0 ]
+        then
+          echo "Docker image already found."
+          exit 0
+        fi
+
         echo "We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out."
         echo "Polling for $IMAGE_URL"
         until docker pull "$IMAGE_URL" 2>/dev/null; do


### PR DESCRIPTION
While trying to get the relay pipeline working for PRs, I was trying to switch to artifacts so we wouldn't run into any permissions issues with ghcr, however because they use this action and it pulls, it would poll until it hit a timeout.

This change will check if an image already exists with the image_url, and if so, skip the docker pull.

Example run: https://github.com/getsentry/relay/actions/runs/4388529499/jobs/7685432250

This still runs into an issue with the self-hosted tests themselves, but that's out of scope for this repo.