### PR TITLE
Timeout docker image poll to 10 min

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,9 +39,7 @@ runs:
       run: |
         echo "We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out."
         echo "Polling for $IMAGE_URL"
-        until docker pull "$IMAGE_URL" 2>/dev/null; do
-           sleep 10
-        done
+        timeout 10m bash -c 'until docker pull "$IMAGE_URL" 2>/dev/null; do sleep 10; done'
     - name: Configure to use the test image
       if: ${{ inputs.project_name != 'self-hosted' }}
       shell: bash


### PR DESCRIPTION
closes https://github.com/getsentry/action-self-hosted-e2e-tests/issues/10

Sample run passing here for image poll that takes < 10 min: https://github.com/getsentry/sentry/actions/runs/4745198182/jobs/8427171719?pr=47637
Sample run with timeout for image polling: https://github.com/getsentry/sentry/actions/runs/4745381575/jobs/8427617469?pr=47637