### PR TITLE
fix: Correctly use test image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,7 @@ runs:
         image_var=$(echo ${{ inputs.project_name }}_IMAGE | tr '[:lower:]' '[:upper:]')
         sed -i "/^$image_var/d" .env
         echo "${image_var}=${{ inputs.image_url }}" >> .env
+        cat .env
 
     - name: Run the installer
       run: |

--- a/action.yml
+++ b/action.yml
@@ -60,9 +60,8 @@ runs:
       run: |
         cd self-hosted
         image_var=$(echo ${{ inputs.project_name }}_IMAGE | tr '[:lower:]' '[:upper:]')
-        cat .env | grep -v $image_var > .env.custom
-        echo "${image_var}=${{ inputs.image_url }}" >> .env.custom
-        cat .env.custom
+        sed -i "/^$image_var/d" .env
+        echo "${image_var}=${{ inputs.image_url }}" >> .env
 
     - name: Run the installer
       run: |


### PR DESCRIPTION
Tests in relay/snuba likely weren't being properly run with the pre-submit images that were built. This led to an event today where a change led to self-hosted e2e test breakage in relay on master that was not caught on the [PR](https://github.com/getsentry/relay/pull/3633). I suspect the custom env file for every commit on a PR wasn't being used for e2e tests that is built here: https://github.com/getsentry/action-self-hosted-e2e-tests/blob/main/action.yml#L64. In the meantime, I think directly writing to the .env file is fine for now, and it works as I have verified in https://github.com/getsentry/self-hosted/actions/runs/9293290182/job/25576089323?pr=3094